### PR TITLE
specify pandas version in cfg file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     envyaml
     numpy>=1.17
     xarray>=0.17.0
-
+    pandas<1.3
 [options.package_data]
 mdtf_test_data =
     config/*


### PR DESCRIPTION
Specify pandas<1.3 to circumvent time slice bug