### PR TITLE
remove 'height' from tas in daily CMIP config

### DIFF
--- a/mdtf_test_data/config/cmip_day.yml
+++ b/mdtf_test_data/config/cmip_day.yml
@@ -20,17 +20,6 @@ tas :
     original_name : 'tas'
   stats :
     - [277.8414001464844, 21.905702590942383]
-  coordinates :
-    name : 'height'
-    value : 2.
-    atts :
-      long_name : "height"
-      units : "m"
-      cell_methods : "time: point"
-      axis : "Z"
-      positive : "up"
-      standard_name : "height"
-      description : "~2 m standard surface air temperature and surface humidity  height"
 psl :
   atts :
     long_name : 'Sea Level Pressure'


### PR DESCRIPTION
The 'height' coordinate for the tas variable is no longer expected for the MDTF framework and causes an error that exits the framework early. This PR removes this coordinate from the variable config yml.