### PR TITLE
Add --freq cli option and refactor driver script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Optional arguments:
   -h, --help            show this help message and exit
   --startyear           start year of data [default is 1975]
   --nyears              number of years of data to generate [default is 10]
+  --freq                frequency of data [default is ["1hr", "3hr", "day", "mon"]]
   --dlat                latitude resolution in degrees [default is 20]
   --dlon                longitude resolution in degrees [default is 20]
   --unittest............flag to run unit tests in mdtf_test_data/tests

--- a/mdtf_test_data/config/cmip_3hr.yml
+++ b/mdtf_test_data/config/cmip_3hr.yml
@@ -1,0 +1,15 @@
+# input data file for generating daily data using CMIP naming conventions
+variables :
+  name :
+    - "pr"
+pr :
+  atts :
+    long_name : "Precipitation"
+    units : "kg m-2 s-1"
+    cell_methods : "time : mean"
+    cell_measures : "area : area"
+    time_avg_info" : "average_T1,average_T2,average_DT"
+    standard_name : "precipitation_flux"
+    interp_method": "conserve_order1"
+  stats :
+    - [3.116272e-05, 2.2157835e-05]

--- a/mdtf_test_data/synthetic/synthetic_setup.py
+++ b/mdtf_test_data/synthetic/synthetic_setup.py
@@ -40,16 +40,8 @@ def create_output_dirs(CASENAME="", STARTYEAR=1, NYEARS=10, TIME_RES="day"):
 
     print("Creating output data directories")
 
-    if not os.path.exists(f"{out_dir_root}/day"):
-        os.makedirs(f"{out_dir_root}/day")
-    if not os.path.exists(f"{out_dir_root}/mon"):
-        os.makedirs(f"{out_dir_root}/mon")
-    if "ncar" in str.lower(out_dir_root):
-        if not os.path.exists(f"{out_dir_root}/3hr"):
-            os.makedirs(f"{out_dir_root}/3hr")
-        if not os.path.exists(f"{out_dir_root}/1hr"):
-            os.makedirs(f"{out_dir_root}/1hr")
-
+    if not os.path.exists(f"{out_dir_root}/{TIME_RES}"):
+        os.makedirs(f"{out_dir_root}/{TIME_RES}")
 
 def synthetic_main(
     yaml_dict={},
@@ -62,7 +54,7 @@ def synthetic_main(
     DATA_FORMAT="",
 ):
     """Main script to generate synthetic data using GFDL naming conventions"""
-    create_output_dirs(CASENAME, STARTYEAR=STARTYEAR, NYEARS=NYEARS)
+    create_output_dirs(CASENAME, STARTYEAR=STARTYEAR, NYEARS=NYEARS, TIME_RES=TIME_RES)
     # parse the yaml dictionary
     var_names = yaml_dict["variables.name"]
     # -- Create Data
@@ -149,13 +141,18 @@ def synthetic_main(
 
         if DATA_FORMAT == "cmip":
             # formulate the date string in the file name
-            date_string = generate_date_string(
+            dir_date_string = generate_date_string(
                 STARTYEAR=STARTYEAR, NYEARS=NYEARS, TIME_RES="day"
             )
+            file_date_string = dir_date_string
+            if TIME_RES == "mon":
+                file_date_string = generate_date_string(
+                    STARTYEAR=STARTYEAR, NYEARS=NYEARS, TIME_RES="mon"
+                )
 
-            outname = f"{CASENAME.replace('.','_')}_r1i1p1f1_gr1_{date_string}.{v}.{TIME_RES}.nc"
+            outname = f"{CASENAME.replace('.','_')}_r1i1p1f1_gr1_{file_date_string}.{v}.{TIME_RES}.nc"
             # output root directory and file name base must match
-            out_dir_root = f"{CASENAME.replace('.','_')}_r1i1p1f1_gr1_{date_string}"
+            out_dir_root = f"{CASENAME.replace('.','_')}_r1i1p1f1_gr1_{dir_date_string}"
         else:
             outname = f"{CASENAME}.{v}.{TIME_RES}.nc"
             out_dir_root = CASENAME

--- a/mdtf_test_data/synthetic/synthetic_setup.py
+++ b/mdtf_test_data/synthetic/synthetic_setup.py
@@ -141,18 +141,13 @@ def synthetic_main(
 
         if DATA_FORMAT == "cmip":
             # formulate the date string in the file name
-            dir_date_string = generate_date_string(
+            date_string = generate_date_string(
                 STARTYEAR=STARTYEAR, NYEARS=NYEARS, TIME_RES="day"
             )
-            file_date_string = dir_date_string
-            if TIME_RES == "mon":
-                file_date_string = generate_date_string(
-                    STARTYEAR=STARTYEAR, NYEARS=NYEARS, TIME_RES="mon"
-                )
 
-            outname = f"{CASENAME.replace('.','_')}_r1i1p1f1_gr1_{file_date_string}.{v}.{TIME_RES}.nc"
+            outname = f"{CASENAME.replace('.','_')}_r1i1p1f1_gr1_{date_string}.{v}.{TIME_RES}.nc"
             # output root directory and file name base must match
-            out_dir_root = f"{CASENAME.replace('.','_')}_r1i1p1f1_gr1_{dir_date_string}"
+            out_dir_root = f"{CASENAME.replace('.','_')}_r1i1p1f1_gr1_{date_string}"
         else:
             outname = f"{CASENAME}.{v}.{TIME_RES}.nc"
             out_dir_root = CASENAME

--- a/mdtf_test_data/util/cli.py
+++ b/mdtf_test_data/util/cli.py
@@ -5,10 +5,11 @@
 class cli_holder(object):
     "Object with command line info from argparse"
 
-    def __init__(self, convention, startyear, nyears, dlat, dlon, unittest):
+    def __init__(self, convention, startyear, nyears, freq, dlat, dlon, unittest):
         self.convention = convention
         self.startyear = startyear
         self.nyears = nyears
+        self.freq = freq
         self.dlat = dlat
         self.dlon = dlon
         self.unittest = unittest

--- a/scripts/mdtf_synthetic.py
+++ b/scripts/mdtf_synthetic.py
@@ -150,7 +150,7 @@ def main():
             continue 
    
         # call generator
-        print(f"Calling Snthetic Data Generator for {input_file}") 
+        print(f"Calling Synthetic Data Generator for {input_file}") 
         synthetic_main(
             input_data,
             DLAT=dlat,

--- a/scripts/mdtf_synthetic.py
+++ b/scripts/mdtf_synthetic.py
@@ -48,6 +48,14 @@ def main():
         default=10,
     )
     parser.add_argument(
+        "--freq",
+        nargs='+',
+        help="Frequency of data",
+        choices=["1hr", "3hr", "day", "mon"],
+        required=False,
+        default='day',
+    )
+    parser.add_argument(
         "--dlat",
         type=float,
         help="Latitude resolution in degrees (will not change default value for NCAR daily data)",
@@ -69,6 +77,7 @@ def main():
         args.convention,
         args.startyear,
         args.nyears,
+        args.freq,
         args.dlat,
         args.dlon,
         args.unittest,
@@ -117,67 +126,47 @@ def main():
             )
             sys.exit(retcode_4)
 
-    if cli_info.convention == "GFDL":
-        print("Importing GFDL variable information")
-        input_data = pkgr.resource_filename("mdtf_test_data", "config/gfdl_day.yml")
-        input_data = read_yaml(input_data)
-
-        print("Calling Synthetic Data Generator for GFDL data")
-        synthetic_main(
-            input_data,
-            DLAT=cli_info.dlat,
-            DLON=cli_info.dlon,
-            STARTYEAR=cli_info.startyear,
-            NYEARS=cli_info.nyears,
-            CASENAME="GFDL.Synthetic",
-            TIME_RES="day",
-            DATA_FORMAT="gfdl",
-        )
-    elif cli_info.convention == "CESM" or cli_info.convention == "NCAR":
-        print("Importing NCAR variable information")
-        time_res = ["mon", "day", "3hr", "1hr"]
-        for t in time_res:
-            input_data = pkgr.resource_filename(
-                "mdtf_test_data", f"config/ncar_{t}.yml"
-            )
-            input_data = read_yaml(input_data)
-            dlat = cli_info.dlat
-            dlon = cli_info.dlon
-            if t == "day":
+    # output for multiple frequencies if requested by user 
+    for freq in cli_info.freq:    
+        
+        # handle requirements for NCAR and CESM
+        conv = cli_info.convention
+        dlat = cli_info.dlat
+        dlon = cli_info.dlon
+        if cli_info.convention == "CESM" or cli_info.convention == "NCAR":
+            conv = "NCAR"
+            if freq == 'day':
                 dlat = 5.0
                 dlon = 5.0
-            print("Calling Synthetic Data Generator for NCAR data")
-            synthetic_main(
-                input_data,
-                DLAT=dlat,
-                DLON=dlon,
-                STARTYEAR=cli_info.startyear,
-                NYEARS=cli_info.nyears,
-                CASENAME="NCAR.Synthetic",
-                TIME_RES=t,
-                DATA_FORMAT="ncar",
-            )
-    if cli_info.convention == "CMIP":
-        print("Importing CMIP variable information")
-        time_res = ["mon", "day"]
-        for t in time_res:
-            input_data = pkgr.resource_filename(
-                "mdtf_test_data", f"config/cmip_{t}.yml"
-            )
+
+        # import variable information
+        print(f"Importing {cli_info.convention} variable for information for {freq} frequency")
+        input_file = f"{conv.lower()}_{freq}.yml"
+        input_data = pkgr.resource_filename("mdtf_test_data", "config/"+input_file)
+        try:
             input_data = read_yaml(input_data)
-
-            print("Calling Synthetic Data Generator for CMIP data")
-            synthetic_main(
-                input_data,
-                DLAT=cli_info.dlat,
-                DLON=cli_info.dlon,
-                STARTYEAR=cli_info.startyear,
-                NYEARS=cli_info.nyears,
-                CASENAME="CMIP.Synthetic",
-                TIME_RES=t,
-                DATA_FORMAT="cmip",
-            )
-
+        except FileNotFoundError:
+            print(f"ERROR: Could not find {input_file} in config dir! Skipping this request.")
+            continue 
+   
+        # call generator
+        print(f"Calling Snthetic Data Generator for {input_file}") 
+        synthetic_main(
+            input_data,
+            DLAT=dlat,
+            DLON=dlon,
+            STARTYEAR=cli_info.startyear,
+            NYEARS=cli_info.nyears,
+            CASENAME=f"{cli_info.convention}.Synthetic",
+            TIME_RES=freq,
+            DATA_FORMAT=conv.lower(),
+        )
+        
+        print(f"Generated data from {input_file}!")
+   
+    # all done! 
+    print(f"Done generating {cli_info.convention} data!")
+    sys.exit(0)    
 
 if __name__ == "__main__":
     main()

--- a/scripts/mdtf_synthetic.py
+++ b/scripts/mdtf_synthetic.py
@@ -53,7 +53,7 @@ def main():
         help="Frequency of data",
         choices=["1hr", "3hr", "day", "mon"],
         required=False,
-        default='day',
+        default=["1hr", "3hr", "day", "mon"],
     )
     parser.add_argument(
         "--dlat",


### PR DESCRIPTION
In the previous iteration, the user wasn't able to specify a certain freq for the output data. This means that, for cases such as NCAR, the code would output multiple freq types. This PR would allow the user to only generate, per se, "day" output only. This PR also allows for a user to easily add configs files for other data types without having to make more edits to the code. For example, I added "cmip_3hr.yml" for testing hi-freq PODs in the MDTF such as "precip_diurnal_cycle". I also made sure this PR doesn't interfere with the current MDTF CI.